### PR TITLE
Feature/machine management

### DIFF
--- a/src/MaintenanceChronicle.Api/Controllers/LocationController.cs
+++ b/src/MaintenanceChronicle.Api/Controllers/LocationController.cs
@@ -3,6 +3,8 @@ using MaintenanceChronicle.Application.Contracts.LocationContactUsers.Queries.Dt
 using MaintenanceChronicle.Application.Contracts.Locations.Commands;
 using MaintenanceChronicle.Application.Contracts.Locations.Commands.Dto;
 using MaintenanceChronicle.Application.Contracts.Locations.Queries.Dto;
+using MaintenanceChronicle.Application.Contracts.Machines.Queries;
+using MaintenanceChronicle.Application.Contracts.Machines.Queries.Dto;
 using MaintenanceChronicle.Application.Contracts.Utils.Commands;
 using MaintenanceChronicle.Application.Contracts.Utils.Queries;
 using MaintenanceChronicle.Data.Entities.Business;
@@ -131,5 +133,19 @@ public class LocationController(IMediator mediator) : ControllerBase
         var contacts = await mediator.Send(getContactsQuery);
 
         return Ok(contacts);
+    }
+
+    /// <summary>
+    /// Gets list of machines for the specified location
+    /// </summary>
+    /// <param name="id">User specified location id</param>
+    /// <returns>List of machines</returns>
+    [HttpGet("/api/v1/location/{id:guid}/machines")]
+    public async Task<ActionResult<List<MachineInListForLocationDto>>> GetMachinesForLocation([FromRoute] Guid id)
+    {
+        var query = new GetMachinesForLocationQuery(id);
+        var machines = await mediator.Send(query);
+
+        return Ok(machines);
     }
 }

--- a/src/MaintenanceChronicle.Api/Controllers/MachineController.cs
+++ b/src/MaintenanceChronicle.Api/Controllers/MachineController.cs
@@ -1,8 +1,10 @@
 using MaintenanceChronicle.Application.Contracts.Machines.Commands;
 using MaintenanceChronicle.Application.Contracts.Machines.Commands.Dto;
 using MaintenanceChronicle.Application.Contracts.Machines.Queries.Dto;
+using MaintenanceChronicle.Application.Contracts.Utils.Commands;
 using MaintenanceChronicle.Application.Contracts.Utils.Queries;
 using MaintenanceChronicle.Application.Machines.Commands;
+using MaintenanceChronicle.Data.Entities.Business;
 using MaintenanceChronicle.Utilities.Constants;
 using MaintenanceChronicle.Utilities.Helpers;
 using MediatR;
@@ -45,6 +47,20 @@ public class MachineController(IMediator mediator) : ControllerBase
         var result = await mediator.Send(command);
 
         return Ok(result);
+    }
+
+    /// <summary>
+    /// Soft deletes machine by specified id
+    /// </summary>
+    /// <param name="id">User specified machine id</param>
+    /// <returns></returns>
+    [HttpDelete("/api/v1/machines/{id:guid}")]
+    public async Task<ActionResult> DeleteMachine([FromRoute] Guid id)
+    {
+        var command = new DeleteEntityByIdCommand<Machine>(id, User.GetUserId());
+        await mediator.Send(command);
+
+        return Ok();
     }
 
     /// <summary>

--- a/src/MaintenanceChronicle.Api/Controllers/MachineController.cs
+++ b/src/MaintenanceChronicle.Api/Controllers/MachineController.cs
@@ -1,4 +1,7 @@
+using MaintenanceChronicle.Application.Contracts.Machines.Commands;
+using MaintenanceChronicle.Application.Contracts.Machines.Commands.Dto;
 using MaintenanceChronicle.Utilities.Constants;
+using MaintenanceChronicle.Utilities.Helpers;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -12,8 +15,11 @@ namespace MaintenanceChronicle.Api.Controllers;
 public class MachineController(IMediator mediator) : ControllerBase
 {
     [HttpPost("/api/v1/machines")]
-    public async Task CreateMachine([FromBody] object newMachineDetail)
+    public async Task<ActionResult<Guid>> CreateMachine([FromBody] NewMachineDto newMachineDetail)
     {
+        var createCommand = new CreateNewMachineCommand(newMachineDetail, User.GetUserId(), User.GetTenantId());
+        var machineId = await mediator.Send(createCommand);
 
+        return Ok(machineId);
     }
 }

--- a/src/MaintenanceChronicle.Api/Controllers/MachineController.cs
+++ b/src/MaintenanceChronicle.Api/Controllers/MachineController.cs
@@ -1,0 +1,19 @@
+using MaintenanceChronicle.Utilities.Constants;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MaintenanceChronicle.Api.Controllers;
+
+//Makes endpoints accessible only for users with Admin or GlobalAdmin roles
+[Authorize(Roles = $"{RoleTypes.Admin},{RoleTypes.GlobalAdmin}")]
+[ApiController]
+public class MachineController(IMediator mediator) : ControllerBase
+{
+    [HttpPost("/api/v1/machines")]
+    public async Task CreateMachine([FromBody] object newMachineDetail)
+    {
+
+    }
+}

--- a/src/MaintenanceChronicle.Api/Controllers/MachineController.cs
+++ b/src/MaintenanceChronicle.Api/Controllers/MachineController.cs
@@ -2,11 +2,13 @@ using MaintenanceChronicle.Application.Contracts.Machines.Commands;
 using MaintenanceChronicle.Application.Contracts.Machines.Commands.Dto;
 using MaintenanceChronicle.Application.Contracts.Machines.Queries.Dto;
 using MaintenanceChronicle.Application.Contracts.Utils.Queries;
+using MaintenanceChronicle.Application.Machines.Commands;
 using MaintenanceChronicle.Utilities.Constants;
 using MaintenanceChronicle.Utilities.Helpers;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
 
 namespace MaintenanceChronicle.Api.Controllers;
@@ -31,10 +33,25 @@ public class MachineController(IMediator mediator) : ControllerBase
     }
 
     /// <summary>
+    /// Updates machine info
+    /// </summary>
+    /// <param name="id">Updated machine id</param>
+    /// <param name="patch">Object that says what props should be changed and how</param>
+    /// <returns>Updated MachineDetail</returns>
+    [HttpPatch("/api/v1/machines/{id:guid}")]
+    public async Task<ActionResult<ManageMachineDetailDto>> UpdateMachine([FromRoute] Guid id, [FromBody] JsonPatchDocument<ManageMachineDetailDto> patch)
+    {
+        var command = new UpdateMachineCommand(patch, id, User.GetUserId());
+        var result = await mediator.Send(command);
+
+        return Ok(result);
+    }
+
+    /// <summary>
     /// Gets machine by specified id
     /// </summary>
     /// <param name="id">Machine id specified by user</param>
-    /// <returns>MachineDetailDto</returns>
+    /// <returns>Patch</returns>
     [HttpGet("/api/v1/machines/{id:guid}")]
     public async Task<ActionResult<MachineDetailDto>> GetMachineById([FromRoute] Guid id)
     {

--- a/src/MaintenanceChronicle.Api/Controllers/MachineController.cs
+++ b/src/MaintenanceChronicle.Api/Controllers/MachineController.cs
@@ -1,5 +1,7 @@
 using MaintenanceChronicle.Application.Contracts.Machines.Commands;
 using MaintenanceChronicle.Application.Contracts.Machines.Commands.Dto;
+using MaintenanceChronicle.Application.Contracts.Machines.Queries.Dto;
+using MaintenanceChronicle.Application.Contracts.Utils.Queries;
 using MaintenanceChronicle.Utilities.Constants;
 using MaintenanceChronicle.Utilities.Helpers;
 using MediatR;
@@ -14,6 +16,11 @@ namespace MaintenanceChronicle.Api.Controllers;
 [ApiController]
 public class MachineController(IMediator mediator) : ControllerBase
 {
+    /// <summary>
+    /// Creates new machine
+    /// </summary>
+    /// <param name="newMachineDetail">Information from user</param>
+    /// <returns>New machine id</returns>
     [HttpPost("/api/v1/machines")]
     public async Task<ActionResult<Guid>> CreateMachine([FromBody] NewMachineDto newMachineDetail)
     {
@@ -21,5 +28,19 @@ public class MachineController(IMediator mediator) : ControllerBase
         var machineId = await mediator.Send(createCommand);
 
         return Ok(machineId);
+    }
+
+    /// <summary>
+    /// Gets machine by specified id
+    /// </summary>
+    /// <param name="id">Machine id specified by user</param>
+    /// <returns>MachineDetailDto</returns>
+    [HttpGet("/api/v1/machines/{id:guid}")]
+    public async Task<ActionResult<MachineDetailDto>> GetMachineById([FromRoute] Guid id)
+    {
+        var machineQuery = new GetEntityByIdQuery<MachineDetailDto>(id);
+        var machine = await mediator.Send(machineQuery);
+
+        return Ok(machine);
     }
 }

--- a/src/MaintenanceChronicle.Api/Controllers/MachineController.cs
+++ b/src/MaintenanceChronicle.Api/Controllers/MachineController.cs
@@ -43,4 +43,17 @@ public class MachineController(IMediator mediator) : ControllerBase
 
         return Ok(machine);
     }
+
+    /// <summary>
+    /// Gets list of machines
+    /// </summary>
+    /// <returns></returns>
+    [HttpGet("/api/v1/machines")]
+    public async Task<ActionResult<List<MachineInListDto>>> GetMachineList()
+    {
+        var query = new GetListOfEntityQuery<MachineInListDto>();
+        var machines = await mediator.Send(query);
+
+        return Ok(machines);
+    }
 }

--- a/src/MaintenanceChronicle.Application.Contracts/Machines/Commands/CreateNewMachineCommand.cs
+++ b/src/MaintenanceChronicle.Application.Contracts/Machines/Commands/CreateNewMachineCommand.cs
@@ -1,0 +1,6 @@
+using MaintenanceChronicle.Application.Contracts.Machines.Commands.Dto;
+using MediatR;
+
+namespace MaintenanceChronicle.Application.Contracts.Machines.Commands;
+
+public record CreateNewMachineCommand(NewMachineDto NewMachineDto, string UserId, string TenantId) : IRequest<Guid>;

--- a/src/MaintenanceChronicle.Application.Contracts/Machines/Commands/Dto/ManageMachineDetailDto.cs
+++ b/src/MaintenanceChronicle.Application.Contracts/Machines/Commands/Dto/ManageMachineDetailDto.cs
@@ -1,0 +1,39 @@
+using MaintenanceChronicle.Data.Entities.Business;
+using NodaTime;
+
+namespace MaintenanceChronicle.Application.Contracts.Machines.Commands.Dto;
+
+public class ManageMachineDetailDto
+{
+    public Guid Id { get; set; }
+    public required string Model { get; set; }
+    public required string Manufacture { get; set; }
+    public required Guid LocationId { get; set; }
+    public required string SerialNumber { get; set; }
+    public required string Color { get; set; }
+    public required Instant InUseSince { get; set; }
+}
+
+public static class ManageMachineDetailExtension
+{
+    public static ManageMachineDetailDto ToManageMachineDetailDto(this Machine entity) => new ManageMachineDetailDto
+    {
+        Id = entity.Id,
+        Color = entity.Color,
+        InUseSince = entity.InUseSince,
+        Manufacture = entity.Manufacture,
+        Model = entity.Model,
+        SerialNumber = entity.SerialNumber,
+        LocationId = entity.LocationId,
+    };
+
+    public static void MapToEntity(this ManageMachineDetailDto dto, Machine target)
+    {
+        target.Model = dto.Model;
+        target.Color = dto.Color;
+        target.Manufacture = dto.Manufacture;
+        target.SerialNumber = dto.SerialNumber;
+        target.InUseSince = dto.InUseSince;
+        target.LocationId = dto.LocationId;
+    }
+}

--- a/src/MaintenanceChronicle.Application.Contracts/Machines/Commands/Dto/NewMachineDto.cs
+++ b/src/MaintenanceChronicle.Application.Contracts/Machines/Commands/Dto/NewMachineDto.cs
@@ -1,0 +1,28 @@
+using MaintenanceChronicle.Data.Entities.Business;
+using NodaTime;
+using NodaTime.Text;
+
+namespace MaintenanceChronicle.Application.Contracts.Machines.Commands.Dto;
+
+public class NewMachineDto
+{
+    public required string Model { get; set; }
+    public required string Manufacture { get; set; }
+    public required Guid LocationId { get; set; }
+    public required string SerialNumber { get; set; }
+    public required string Color { get; set; }
+    public required string InUseSince { get; set; }
+}
+
+public static class NewMachineDtoExtension
+{
+    public static Machine ToMachineEntity(this NewMachineDto newMachineDto) => new Machine
+    {
+        Model = newMachineDto.Model,
+        Manufacture = newMachineDto.Manufacture,
+        Color = newMachineDto.Color,
+        SerialNumber = newMachineDto.SerialNumber,
+        InUseSince = InstantPattern.General.Parse(newMachineDto.InUseSince).Value,
+        LocationId = newMachineDto.LocationId,
+    };
+}

--- a/src/MaintenanceChronicle.Application.Contracts/Machines/Commands/UpdateMachineCommand.cs
+++ b/src/MaintenanceChronicle.Application.Contracts/Machines/Commands/UpdateMachineCommand.cs
@@ -1,0 +1,8 @@
+using MaintenanceChronicle.Application.Contracts.Machines.Commands.Dto;
+using MediatR;
+using Microsoft.AspNetCore.JsonPatch;
+
+namespace MaintenanceChronicle.Application.Contracts.Machines.Commands;
+
+public record UpdateMachineCommand(JsonPatchDocument<ManageMachineDetailDto> Patch, Guid MachineId, string UserId)
+    : IRequest<ManageMachineDetailDto>;

--- a/src/MaintenanceChronicle.Application.Contracts/Machines/Queries/Dto/MachineDetailDto.cs
+++ b/src/MaintenanceChronicle.Application.Contracts/Machines/Queries/Dto/MachineDetailDto.cs
@@ -13,7 +13,7 @@ public class MachineDetailDto
     public Instant InUseSince { get; set; }
 }
 
-public static class MachineDetailDtoExtensio
+public static class MachineDetailDtoExtension
 {
     public static MachineDetailDto ToMachineDetailDto(this Machine entity) => new MachineDetailDto
     {

--- a/src/MaintenanceChronicle.Application.Contracts/Machines/Queries/Dto/MachineDetailDto.cs
+++ b/src/MaintenanceChronicle.Application.Contracts/Machines/Queries/Dto/MachineDetailDto.cs
@@ -1,0 +1,27 @@
+using MaintenanceChronicle.Data.Entities.Business;
+using NodaTime;
+
+namespace MaintenanceChronicle.Application.Contracts.Machines.Queries.Dto;
+
+public class MachineDetailDto
+{
+    public Guid Id { get; set; }
+    public required string Model { get; set; }
+    public required string Manufacture { get; set; }
+    public required string  SerialNumber { get; set; }
+    public required string Color { get; set; }
+    public Instant InUseSince { get; set; }
+}
+
+public static class MachineDetailDtoExtensio
+{
+    public static MachineDetailDto ToMachineDetailDto(this Machine entity) => new MachineDetailDto
+    {
+        Id = entity.Id,
+        Color = entity.Color,
+        InUseSince = entity.InUseSince,
+        Manufacture = entity.Manufacture,
+        Model = entity.Model,
+        SerialNumber = entity.SerialNumber
+    };
+}

--- a/src/MaintenanceChronicle.Application.Contracts/Machines/Queries/Dto/MachineInListDto.cs
+++ b/src/MaintenanceChronicle.Application.Contracts/Machines/Queries/Dto/MachineInListDto.cs
@@ -1,0 +1,20 @@
+using MaintenanceChronicle.Data.Entities.Business;
+
+namespace MaintenanceChronicle.Application.Contracts.Machines.Queries.Dto;
+
+public class MachineInListDto
+{
+    public Guid Id { get; set; }
+    public required string Model { get; set; }
+    public required string LocationName { get; set; }
+}
+
+public static  class MachineInListExtension
+{
+    public static MachineInListDto ToMachineInListDto(this Machine entity) => new MachineInListDto
+    {
+        Id = entity.Id,
+        Model = entity.Model,
+        LocationName = entity.Location.Name,
+    };
+}

--- a/src/MaintenanceChronicle.Application.Contracts/Machines/Queries/Dto/MachineInListForLocationDto.cs
+++ b/src/MaintenanceChronicle.Application.Contracts/Machines/Queries/Dto/MachineInListForLocationDto.cs
@@ -1,0 +1,20 @@
+using MaintenanceChronicle.Data.Entities.Business;
+
+namespace MaintenanceChronicle.Application.Contracts.Machines.Queries.Dto;
+
+public class MachineInListForLocationDto
+{
+    public Guid Id { get; set; }
+    public required string Model { get; set; }
+    public required string SerialNumber { get; set; }
+}
+
+public static class MachineInListForLocationExtension
+{
+    public static MachineInListForLocationDto ToMachineInListForLocationDto(this Machine entity) => new MachineInListForLocationDto
+    {
+        Id = entity.Id,
+        Model = entity.Model,
+        SerialNumber = entity.SerialNumber,
+    };
+}

--- a/src/MaintenanceChronicle.Application.Contracts/Machines/Queries/GetMachinesForLocationQuery.cs
+++ b/src/MaintenanceChronicle.Application.Contracts/Machines/Queries/GetMachinesForLocationQuery.cs
@@ -1,0 +1,6 @@
+using MaintenanceChronicle.Application.Contracts.Machines.Queries.Dto;
+using MediatR;
+
+namespace MaintenanceChronicle.Application.Contracts.Machines.Queries;
+
+public record GetMachinesForLocationQuery(Guid LocationId) : IRequest<List<MachineInListForLocationDto>>;

--- a/src/MaintenanceChronicle.Application.Contracts/MaintenanceChronicle.Application.Contracts.csproj
+++ b/src/MaintenanceChronicle.Application.Contracts/MaintenanceChronicle.Application.Contracts.csproj
@@ -13,6 +13,8 @@
 
     <ItemGroup>
         <Folder Include="Locations\Queries\Dto\" />
+        <Folder Include="Machines\Commands\Dto\" />
+        <Folder Include="Machines\Queries\Dto\" />
         <Folder Include="Users\Queries\Dto\" />
     </ItemGroup>
 

--- a/src/MaintenanceChronicle.Application/Machines/Commands/CreateNewMachineCommandHandler.cs
+++ b/src/MaintenanceChronicle.Application/Machines/Commands/CreateNewMachineCommandHandler.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks.Dataflow;
+using MaintenanceChronicle.Application.Contracts.Machines.Commands;
+using MaintenanceChronicle.Application.Contracts.Machines.Commands.Dto;
+using MaintenanceChronicle.Data;
+using MaintenanceChronicle.Data.Interfaces;
+using MaintenanceChronicle.Utilities.Error;
+using MediatR;
+using NodaTime;
+
+namespace MaintenanceChronicle.Application.Machines.Commands;
+
+public class CreateNewMachineCommandHandler(AppDbContext dbContext, IClock clock) : IRequestHandler<CreateNewMachineCommand, Guid>
+{
+    public async Task<Guid> Handle(CreateNewMachineCommand request, CancellationToken cancellationToken)
+    {
+        if (await dbContext.Locations.FindAsync(new object[] { request.NewMachineDto.LocationId }, cancellationToken) ==
+            null)
+        {
+            throw new BadRequestException(ErrorType.LocationNotFound);
+        }
+
+        var machineEntity = request.NewMachineDto.ToMachineEntity();
+        machineEntity.TenantId = Guid.Parse(request.TenantId);
+        machineEntity.SetCreateBy(request.UserId, clock.GetCurrentInstant());
+
+        await dbContext.AddAsync(machineEntity, cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return machineEntity.Id;
+    }
+}

--- a/src/MaintenanceChronicle.Application/Machines/Commands/DeleteMachineCommandHandler.cs
+++ b/src/MaintenanceChronicle.Application/Machines/Commands/DeleteMachineCommandHandler.cs
@@ -1,0 +1,24 @@
+using MaintenanceChronicle.Application.Contracts.Utils.Commands;
+using MaintenanceChronicle.Data;
+using MaintenanceChronicle.Data.Entities.Business;
+using MaintenanceChronicle.Data.Interfaces;
+using MaintenanceChronicle.Utilities.Error;
+using MediatR;
+using NodaTime;
+
+namespace MaintenanceChronicle.Application.Machines.Commands;
+
+public class DeleteMachineCommandHandler(AppDbContext dbContext, IClock clock) : IRequestHandler<DeleteEntityByIdCommand<Machine>>
+{
+    public async Task Handle(DeleteEntityByIdCommand<Machine> request, CancellationToken cancellationToken)
+    {
+        var machine = await dbContext.Machines.FindAsync(new object[] { request.Id }, cancellationToken);
+        if (machine is null)
+        {
+            throw new BadRequestException(ErrorType.MachineNotFound);
+        }
+        machine.SetDeleteBy(request.UserId, clock.GetCurrentInstant());
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/MaintenanceChronicle.Application/Machines/Commands/UpdateMachineCommandHandler.cs
+++ b/src/MaintenanceChronicle.Application/Machines/Commands/UpdateMachineCommandHandler.cs
@@ -1,0 +1,40 @@
+using MaintenanceChronicle.Application.Contracts.Machines.Commands;
+using MaintenanceChronicle.Application.Contracts.Machines.Commands.Dto;
+using MaintenanceChronicle.Data;
+using MaintenanceChronicle.Data.Interfaces;
+using MaintenanceChronicle.Utilities.Error;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
+
+namespace MaintenanceChronicle.Application.Machines.Commands;
+
+public class UpdateMachineCommandHandler(AppDbContext dbContext, IClock clock) : IRequestHandler<UpdateMachineCommand,ManageMachineDetailDto>
+{
+    public async Task<ManageMachineDetailDto> Handle(UpdateMachineCommand request, CancellationToken cancellationToken)
+    {
+        var machineEntity = await dbContext.Machines.FindAsync(new object[] { request.MachineId }, cancellationToken);
+        if (machineEntity is null)
+        {
+            throw new BadRequestException(ErrorType.MachineNotFound);
+        }
+
+        var machineDetail = machineEntity.ToManageMachineDetailDto();
+
+        request.Patch.ApplyTo(machineDetail);
+
+        if (!(await dbContext
+                .Locations
+                .AnyAsync(l => l.Id == machineDetail.LocationId, cancellationToken)))
+        {
+            throw new BadRequestException(ErrorType.LocationNotFound);
+        }
+
+        machineDetail.MapToEntity(machineEntity);
+        machineEntity.SetModifyBy(request.UserId, clock.GetCurrentInstant());
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return machineDetail;
+    }
+}

--- a/src/MaintenanceChronicle.Application/Machines/Queries/GetListOfMachinesForLocationQueryHandler.cs
+++ b/src/MaintenanceChronicle.Application/Machines/Queries/GetListOfMachinesForLocationQueryHandler.cs
@@ -1,0 +1,27 @@
+using MaintenanceChronicle.Application.Contracts.Machines.Queries;
+using MaintenanceChronicle.Application.Contracts.Machines.Queries.Dto;
+using MaintenanceChronicle.Data;
+using MaintenanceChronicle.Utilities.Error;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace MaintenanceChronicle.Application.Machines.Queries;
+
+public class GetMachinesForLocationQueryHandler(AppDbContext dbContext) : IRequestHandler<GetMachinesForLocationQuery, List<MachineInListForLocationDto>>
+{
+    public async Task<List<MachineInListForLocationDto>> Handle(GetMachinesForLocationQuery request, CancellationToken cancellationToken)
+    {
+        if (!await dbContext.Locations.AnyAsync(l => l.Id == request.LocationId, cancellationToken: cancellationToken))
+        {
+            throw new BadRequestException(ErrorType.LocationNotFound);
+        }
+
+        var machines = await dbContext.Machines
+            .Include(m => m.Location)
+            .Where(m => m.LocationId == request.LocationId)
+            .Select(m => m.ToMachineInListForLocationDto())
+            .ToListAsync(cancellationToken: cancellationToken);
+
+        return machines;
+    }
+}

--- a/src/MaintenanceChronicle.Application/Machines/Queries/GetListOfMachinesQueryHandler.cs
+++ b/src/MaintenanceChronicle.Application/Machines/Queries/GetListOfMachinesQueryHandler.cs
@@ -1,0 +1,21 @@
+using MaintenanceChronicle.Application.Contracts.Machines.Queries.Dto;
+using MaintenanceChronicle.Application.Contracts.Utils.Queries;
+using MaintenanceChronicle.Data;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace MaintenanceChronicle.Application.Machines.Queries;
+
+public class GetListOfMachinesQueryHandler(AppDbContext dbContext) : IRequestHandler<GetListOfEntityQuery<MachineInListDto>, List<MachineInListDto>>
+{
+    public async Task<List<MachineInListDto>> Handle(GetListOfEntityQuery<MachineInListDto> request,
+        CancellationToken cancellationToken)
+    {
+        var machines = await dbContext.Machines
+            .Include(m => m.Location)
+            .Select(m => m.ToMachineInListDto())
+            .ToListAsync(cancellationToken: cancellationToken);
+
+        return machines;
+    }
+}

--- a/src/MaintenanceChronicle.Application/Machines/Queries/GetMachineByIdQueryHandler.cs
+++ b/src/MaintenanceChronicle.Application/Machines/Queries/GetMachineByIdQueryHandler.cs
@@ -1,0 +1,23 @@
+using MaintenanceChronicle.Application.Contracts.Machines.Queries.Dto;
+using MaintenanceChronicle.Application.Contracts.Utils.Queries;
+using MaintenanceChronicle.Data;
+using MaintenanceChronicle.Utilities.Error;
+using MediatR;
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace MaintenanceChronicle.Application.Machines.Queries;
+
+public class GetMachineByIdQueryHandler(AppDbContext dbContext) : IRequestHandler<GetEntityByIdQuery<MachineDetailDto>, MachineDetailDto>
+{
+    public async Task<MachineDetailDto> Handle(GetEntityByIdQuery<MachineDetailDto> request,
+        CancellationToken cancellationToken)
+    {
+        var machine = await dbContext.Machines.FindAsync(new object[] { request.Id }, cancellationToken);
+        if (machine is null)
+        {
+            throw new BadRequestException(ErrorType.MachineNotFound);
+        }
+
+        return machine.ToMachineDetailDto();
+    }
+}

--- a/src/MaintenanceChronicle.Application/Machines/Queries/GetMachineByIdQueryHandler.cs
+++ b/src/MaintenanceChronicle.Application/Machines/Queries/GetMachineByIdQueryHandler.cs
@@ -3,6 +3,7 @@ using MaintenanceChronicle.Application.Contracts.Utils.Queries;
 using MaintenanceChronicle.Data;
 using MaintenanceChronicle.Utilities.Error;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
 
 namespace MaintenanceChronicle.Application.Machines.Queries;
@@ -19,5 +20,18 @@ public class GetMachineByIdQueryHandler(AppDbContext dbContext) : IRequestHandle
         }
 
         return machine.ToMachineDetailDto();
+    }
+}
+public class GetListOfMachinesQueryHandler(AppDbContext dbContext) : IRequestHandler<GetListOfEntityQuery<MachineInListDto>, List<MachineInListDto>>
+{
+    public async Task<List<MachineInListDto>> Handle(GetListOfEntityQuery<MachineInListDto> request,
+        CancellationToken cancellationToken)
+    {
+        var machines = await dbContext.Machines
+            .Include(m => m.Location)
+            .Select(m => m.ToMachineInListDto())
+            .ToListAsync(cancellationToken: cancellationToken);
+
+        return machines;
     }
 }

--- a/src/MaintenanceChronicle.Application/Machines/Queries/GetMachineByIdQueryHandler.cs
+++ b/src/MaintenanceChronicle.Application/Machines/Queries/GetMachineByIdQueryHandler.cs
@@ -3,7 +3,6 @@ using MaintenanceChronicle.Application.Contracts.Utils.Queries;
 using MaintenanceChronicle.Data;
 using MaintenanceChronicle.Utilities.Error;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
 
 namespace MaintenanceChronicle.Application.Machines.Queries;
@@ -20,18 +19,5 @@ public class GetMachineByIdQueryHandler(AppDbContext dbContext) : IRequestHandle
         }
 
         return machine.ToMachineDetailDto();
-    }
-}
-public class GetListOfMachinesQueryHandler(AppDbContext dbContext) : IRequestHandler<GetListOfEntityQuery<MachineInListDto>, List<MachineInListDto>>
-{
-    public async Task<List<MachineInListDto>> Handle(GetListOfEntityQuery<MachineInListDto> request,
-        CancellationToken cancellationToken)
-    {
-        var machines = await dbContext.Machines
-            .Include(m => m.Location)
-            .Select(m => m.ToMachineInListDto())
-            .ToListAsync(cancellationToken: cancellationToken);
-
-        return machines;
     }
 }

--- a/src/MaintenanceChronicle.Application/MaintenanceChronicle.Application.csproj
+++ b/src/MaintenanceChronicle.Application/MaintenanceChronicle.Application.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <Folder Include="Customers\Commands\" />
-    <Folder Include="Machines\Commands\" />
     <Folder Include="Machines\Queries\Dto\" />
     <Folder Include="Tenants\Queries\" />
     <Folder Include="Users\Queries\" />

--- a/src/MaintenanceChronicle.Application/MaintenanceChronicle.Application.csproj
+++ b/src/MaintenanceChronicle.Application/MaintenanceChronicle.Application.csproj
@@ -12,6 +12,8 @@
 
   <ItemGroup>
     <Folder Include="Customers\Commands\" />
+    <Folder Include="Machines\Commands\" />
+    <Folder Include="Machines\Queries\Dto\" />
     <Folder Include="Tenants\Queries\" />
     <Folder Include="Users\Queries\" />
     <Folder Include="UserTenant\Commands\" />

--- a/src/MaintenanceChronicle.Data/AppDbContext.cs
+++ b/src/MaintenanceChronicle.Data/AppDbContext.cs
@@ -16,6 +16,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options, ICurrentTenant
     public DbSet<Customer> Customers { get; set; } = null!;
     public DbSet<Location> Locations { get; set; } = null!;
     public DbSet<LocationContactUser> LocationContactUsers { get; set; } = null!;
+    public DbSet<Machine> Machines { get; set; } = null!;
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -26,6 +27,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options, ICurrentTenant
         modelBuilder.Entity<Customer>().HasQueryFilter(b => (currentTenantProvider.TenantId == Guid.Empty || b.TenantId == currentTenantProvider.TenantId) && b.DeletedAt == null);
         modelBuilder.Entity<Location>().HasQueryFilter(b => (currentTenantProvider.TenantId == Guid.Empty || b.TenantId == currentTenantProvider.TenantId) && b.DeletedAt == null);
         modelBuilder.Entity<LocationContactUser>().HasQueryFilter(b => (currentTenantProvider.TenantId == Guid.Empty || b.TenantId == currentTenantProvider.TenantId) && b.DeletedAt == null);
+        modelBuilder.Entity<Machine>().HasQueryFilter(b => (currentTenantProvider.TenantId == Guid.Empty || b.TenantId == currentTenantProvider.TenantId) && b.DeletedAt == null);
 
         modelBuilder.Entity<UserRole>()
             .HasOne(e => e.Role)

--- a/src/MaintenanceChronicle.Data/Entities/Business/Machine.cs
+++ b/src/MaintenanceChronicle.Data/Entities/Business/Machine.cs
@@ -5,18 +5,17 @@ using NodaTime;
 
 namespace MaintenanceChronicle.Data.Entities.Business;
 
-[Table(nameof(Location))]
-public class Location : ITrackable, ITenant
+[Table(nameof(Machine))]
+public class Machine : ITrackable, ITenant
 {
     public Guid Id { get; set; }
-    public string Name { get; set; } = null!;
-    public string Street { get; set; } = null!;
-    public string City { get; set; } = null!;
-    public string Country { get; set; } = null!;
-    public Guid CustomerId { get; set; }
-    public Customer Customer { get; set; } = null!;
-    public ICollection<LocationContactUser> Contacts { get; set; } = new HashSet<LocationContactUser>();
-    public ICollection<Machine> Machines { get; set; } = new HashSet<Machine>();
+    public string Model { get; set; } = null!;
+    public string Manufacture { get; set; } = null!;
+    public Guid LocationId { get; set; }
+    public Location Location { get; set; } = null!;
+    public string SerialNumber { get; set; } = null!;
+    public string Color { get; set; } = null!;
+    public Instant InUseSince { get; set; }
     public Instant CreatedAt { get; set; }
     public string CreatedBy { get; set; } = null!;
     public Instant ModifiedAt { get; set; }

--- a/src/MaintenanceChronicle.Data/Migrations/20241219095945_MachineAdded.Designer.cs
+++ b/src/MaintenanceChronicle.Data/Migrations/20241219095945_MachineAdded.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MaintenanceChronicle.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MaintenanceChronicle.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241219095945_MachineAdded")]
+    partial class MachineAdded
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/MaintenanceChronicle.Data/Migrations/20241219095945_MachineAdded.cs
+++ b/src/MaintenanceChronicle.Data/Migrations/20241219095945_MachineAdded.cs
@@ -1,0 +1,69 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NodaTime;
+
+#nullable disable
+
+namespace MaintenanceChronicle.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class MachineAdded : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Machine",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Model = table.Column<string>(type: "text", nullable: false),
+                    Manufacture = table.Column<string>(type: "text", nullable: false),
+                    LocationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SerialNumber = table.Column<string>(type: "text", nullable: false),
+                    Color = table.Column<string>(type: "text", nullable: false),
+                    InUseSince = table.Column<Instant>(type: "timestamp with time zone", nullable: false),
+                    CreatedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    ModifiedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: false),
+                    ModifiedBy = table.Column<string>(type: "text", nullable: false),
+                    DeletedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Machine", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Machine_Location_LocationId",
+                        column: x => x.LocationId,
+                        principalTable: "Location",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Machine_Tenant_TenantId",
+                        column: x => x.TenantId,
+                        principalTable: "Tenant",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Machine_LocationId",
+                table: "Machine",
+                column: "LocationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Machine_TenantId",
+                table: "Machine",
+                column: "TenantId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Machine");
+        }
+    }
+}

--- a/src/MaintenanceChronicle.Utilities/Error/ErrorType.cs
+++ b/src/MaintenanceChronicle.Utilities/Error/ErrorType.cs
@@ -25,5 +25,7 @@ public enum ErrorType
     [ErrorMessage("Sorry you don't have access to this tenant!")]
     UserNotInTenant,
     [ErrorMessage("Sorry this location doesn't exist!")]
-    LocationNotFound
+    LocationNotFound,
+    [ErrorMessage("Sorry this machine doesn't exist!")]
+    MachineNotFound
 }


### PR DESCRIPTION
This pull request introduces significant changes to the MaintenanceChronicle API, primarily focusing on adding support for managing machine entities. The changes include new endpoints in the API, new command and query handlers, and DTOs for machine-related data.

### API Enhancements:
* Added `MachineController` with endpoints to create, update, delete, and retrieve machines. These endpoints are restricted to users with Admin or GlobalAdmin roles.
* Added a new endpoint in `LocationController` to get a list of machines for a specified location.

### Command and Query Handlers:
* Implemented `CreateNewMachineCommandHandler`, `UpdateMachineCommandHandler`, `DeleteMachineCommandHandler`, `GetMachinesForLocationQueryHandler`, `GetListOfMachinesQueryHandler`, and `GetMachineByIdQueryHandler` to handle respective operations for machine entities. [[1]](diffhunk://#diff-0d50952e9e75fa6ef4ca2dc3ef2a22ceea433b4f6ef7bd8e5cd3f6a6bbf089dfR1-R31) [[2]](diffhunk://#diff-22fdd1735d46efee230f20cff1bf04ccb409f37558f90c3490127519a8f42d04R1-R40) [[3]](diffhunk://#diff-41447660d9f1a4146dd5bb6deb63e50b6cb720a5f391ff0b1dbd8d0d188d299aR1-R24) [[4]](diffhunk://#diff-d57aadacb0385b47fb086a02bee109f8efec092f4674e47cf533b5862e2595aeR1-R27) [[5]](diffhunk://#diff-c3d4380335c0bd42c83b60ad33eca8c3d31a17e12b5fe8a4fb8100cde59adc33R1-R21) [[6]](diffhunk://#diff-a62bb90fd880dfe4defce956dba33cf8f9e9274e96129820b61f1449e67b794aR1-R23)

### Data Transfer Objects (DTOs):
* Introduced various DTOs such as `NewMachineDto`, `ManageMachineDetailDto`, `MachineDetailDto`, `MachineInListDto`, and `MachineInListForLocationDto` to facilitate data transfer between the API and the application layer. [[1]](diffhunk://#diff-9499727007480027a339f6ae85ad145ee7a01a5cfe1d88a897ae0e5cb78adf1eR1-R28) [[2]](diffhunk://#diff-b175e5a4eb0e252e8eb5ce2021fabe76ae1811812b075faecd281f77b575e26cR1-R39) [[3]](diffhunk://#diff-92a555ba6565b7fbb21bd9e1e3ba4eee68c24c34bd5b8df164763178131b5698R1-R27) [[4]](diffhunk://#diff-1b876195ae603ccb23d58fd5b40f15c76d15cc0422f42d15e733e40f5adced23R1-R20) [[5]](diffhunk://#diff-ce18e1e30b9752a4aff868853c3e7e4e7f52c748718a3d886cd3e2dc93054298R1-R20)

### Database Context:
* Updated `AppDbContext` to include a `DbSet<Machine>` for managing machine entities.

These changes collectively enhance the MaintenanceChronicle API's capability to manage machine-related data, providing a more comprehensive toolset for users to interact with machine entities.