### PR TITLE
Removed the ability to change the customer in Patch for location.

### DIFF
--- a/src/MaintenanceChronicle.Application.Contracts/Locations/Commands/Dto/ManageLocationDetailDto.cs
+++ b/src/MaintenanceChronicle.Application.Contracts/Locations/Commands/Dto/ManageLocationDetailDto.cs
@@ -9,7 +9,6 @@ public class ManageLocationDetailDto
     public required string Street { get; set; }
     public required string City { get; set; }
     public required string Country { get; set; }
-    public Guid CustomerId { get; set; }
 }
 
 public static class ManageLocationDetailDtoExtension
@@ -23,7 +22,6 @@ public static class ManageLocationDetailDtoExtension
             Street = location.Street,
             City = location.City,
             Country = location.Country,
-            CustomerId = location.CustomerId
         };
     }
     public static void MapToEntity(this ManageLocationDetailDto manageLocationDetailDto, Location target)
@@ -33,6 +31,5 @@ public static class ManageLocationDetailDtoExtension
         target.Street = manageLocationDetailDto.Street;
         target.City = manageLocationDetailDto.City;
         target.Country = manageLocationDetailDto.Country;
-        target.CustomerId = manageLocationDetailDto.CustomerId;
     }
 }

--- a/src/MaintenanceChronicle.Application/Locations/Commands/UpdateLocationCommandHandler.cs
+++ b/src/MaintenanceChronicle.Application/Locations/Commands/UpdateLocationCommandHandler.cs
@@ -12,7 +12,7 @@ public class UpdateLocationCommandHandler(AppDbContext dbContext, IClock clock) 
 {
     public async Task<ManageLocationDetailDto> Handle(UpdateLocationCommand request, CancellationToken cancellationToken)
     {
-        var locationEntity = await dbContext.Locations.FindAsync(request.LocationId, cancellationToken);
+        var locationEntity = await dbContext.Locations.FindAsync([request.LocationId], cancellationToken);
         if (locationEntity == null)
         {
             throw new BadRequestException(ErrorType.LocationNotFound);


### PR DESCRIPTION
This pull request includes several changes to the `ManageLocationDetailDto` and `UpdateLocationCommandHandler` classes to remove the `CustomerId` property and fix an issue with the `FindAsync` method. The most important changes are as follows:

Removal of `CustomerId` property:

* [`src/MaintenanceChronicle.Application.Contracts/Locations/Commands/Dto/ManageLocationDetailDto.cs`](diffhunk://#diff-afc1ca8e34f2651fd56cf2e444bc0f15275b99f914f7946fa75178801db18d9bL12): Removed the `CustomerId` property from the `ManageLocationDetailDto` class.
* [`src/MaintenanceChronicle.Application.Contracts/Locations/Commands/Dto/ManageLocationDetailDto.cs`](diffhunk://#diff-afc1ca8e34f2651fd56cf2e444bc0f15275b99f914f7946fa75178801db18d9bL26): Removed the mapping of `CustomerId` in the `ToManageDto` extension method.
* [`src/MaintenanceChronicle.Application.Contracts/Locations/Commands/Dto/ManageLocationDetailDto.cs`](diffhunk://#diff-afc1ca8e34f2651fd56cf2e444bc0f15275b99f914f7946fa75178801db18d9bL36): Removed the mapping of `CustomerId` in the `MapToEntity` extension method.

Fix for `FindAsync` method:

* [`src/MaintenanceChronicle.Application/Locations/Commands/UpdateLocationCommandHandler.cs`](diffhunk://#diff-5773c9fafea265afadd398b066b59e2884beff21a3830ded28eb827f9f7719deL15-R15): Corrected the `FindAsync` method call to use square brackets around `request.LocationId`.