### PR TITLE
Fixed GetListOfContactsForLocationQueryHandler

### DIFF
--- a/src/MaintenanceChronicle.Application/LocationContactUsers/Queries/GetListOfContactsForLocationQueryHandler.cs
+++ b/src/MaintenanceChronicle.Application/LocationContactUsers/Queries/GetListOfContactsForLocationQueryHandler.cs
@@ -14,6 +14,7 @@ public class GetListOfContactsForLocationQueryHandler(AppDbContext dbContext) : 
         var contacts = await dbContext.LocationContactUsers
             .Include(c => c.User)
             .Include(c => c.Location)
+            .Where(l => l.LocationId == request.LocationId)
             .Select(c => c.ToLocationContactInListDto())
             .ToListAsync(cancellationToken);
 


### PR DESCRIPTION
This pull request includes a small but important change to the `GetListOfContactsForLocationQueryHandler.cs` file. The change ensures that the query filters the contacts by `LocationId` before selecting them.

* [`src/MaintenanceChronicle.Application/LocationContactUsers/Queries/GetListOfContactsForLocationQueryHandler.cs`](diffhunk://#diff-0f28469f1077a01a65c61f7b96fca62365dc49cbf69e3fe9e8da55b6a9febf70R17): Added a `Where` clause to filter contacts by `LocationId` in the `Handle` method.…y for the specified location