### PR TITLE
Changed endpoints from PascalCase to kebab-case

### DIFF
--- a/src/MaintenanceChronicle.Api/Controllers/AuthController.cs
+++ b/src/MaintenanceChronicle.Api/Controllers/AuthController.cs
@@ -125,7 +125,7 @@ public class AuthController(IMediator mediator) : ControllerBase
     /// </summary>
     /// <param name="email">Users email that specifies which user should get the email</param>
     /// <returns></returns>
-    [HttpPost("api/v1/auth/sendEmailConfirmEmail")]
+    [HttpPost("api/v1/auth/send-email-confirm-email")]
     public async Task<ActionResult> GenerateEmailConfirmationEmail([FromQuery] string email)
     {
         var generateEmailConfirmationTokenForUserCommand = new GenerateEmailConfirmationEmailForUserCommand(email);
@@ -142,7 +142,7 @@ public class AuthController(IMediator mediator) : ControllerBase
     /// </summary>
     /// <param name="confirmTokenForUserDto">Email and the given token for email confirmation</param>
     /// <returns></returns>
-    [HttpPost("api/v1/auth/validateToken")]
+    [HttpPost("api/v1/auth/validate-token")]
     public async Task<ActionResult> ValidateToken(
         [FromQuery] EmailConfirmTokenForUserDto confirmTokenForUserDto
     )
@@ -158,7 +158,7 @@ public class AuthController(IMediator mediator) : ControllerBase
     /// </summary>
     /// <param name="email">Users email that specifies which user should get the email</param>
     /// <returns></returns>
-    [HttpPost("api/v1/auth/sendPasswordReset")]
+    [HttpPost("api/v1/auth/send-password-reset")]
     public async Task<ActionResult> GeneratePasswordResetEmail([FromQuery] string email)
     {
         var generatePasswordResetEmailForUserCommand = new GeneratePasswordResetEmailForUserCommand(email);
@@ -175,7 +175,7 @@ public class AuthController(IMediator mediator) : ControllerBase
     /// </summary>
     /// <param name="userResetPasswordDto"></param>
     /// <returns></returns>
-    [HttpPost("api/v1/auth/resetPassword")]
+    [HttpPost("api/v1/auth/reset-password")]
     public async Task<ActionResult> ResetPassword([FromBody] UserResetPasswordDto userResetPasswordDto)
     {
         var command = new ResetPasswordForUserCommand(userResetPasswordDto);


### PR DESCRIPTION
This pull request includes changes to the `src/MaintenanceChronicle.Api/Controllers/AuthController.cs` file to standardize the endpoint URLs for better readability and consistency. The most important changes are the renaming of several endpoint URLs.

Endpoint URL standardization:

* Changed the endpoint URL from `api/v1/auth/sendEmailConfirmEmail` to `api/v1/auth/send-email-confirm-email` for the `GenerateEmailConfirmationEmail` method.
* Changed the endpoint URL from `api/v1/auth/validateToken` to `api/v1/auth/validate-token` for the `ValidateToken` method.
* Changed the endpoint URL from `api/v1/auth/sendPasswordReset` to `api/v1/auth/send-password-reset` for the `GeneratePasswordResetEmail` method.
* Changed the endpoint URL from `api/v1/auth/resetPassword` to `api/v1/auth/reset-password` for the `ResetPassword` method.