### PR TITLE
Added Technician role to Authorize attrubute

### DIFF
--- a/src/MaintenanceChronicle.Api/Controllers/CustomerController.cs
+++ b/src/MaintenanceChronicle.Api/Controllers/CustomerController.cs
@@ -15,7 +15,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace MaintenanceChronicle.Api.Controllers;
 
 //Makes endpoints accessible only for users with Admin or GlobalAdmin roles
-[Authorize(Roles = $"{RoleTypes.Admin},{RoleTypes.GlobalAdmin}")]
+[Authorize(Roles = $"{RoleTypes.Admin},{RoleTypes.GlobalAdmin},{RoleTypes.Technician}")]
 [ApiController]
 public class CustomerController(IMediator mediator) : ControllerBase
 {

--- a/src/MaintenanceChronicle.Api/Controllers/LocationController.cs
+++ b/src/MaintenanceChronicle.Api/Controllers/LocationController.cs
@@ -20,7 +20,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace MaintenanceChronicle.Api.Controllers;
 
 //Makes endpoints accessible only for users with Admin or GlobalAdmin roles
-[Authorize(Roles = $"{RoleTypes.Admin},{RoleTypes.GlobalAdmin}")]
+[Authorize(Roles = $"{RoleTypes.Admin},{RoleTypes.GlobalAdmin},{RoleTypes.Technician}")]
 [ApiController]
 public class LocationController(IMediator mediator) : ControllerBase
 {

--- a/src/MaintenanceChronicle.Api/Controllers/MachineController.cs
+++ b/src/MaintenanceChronicle.Api/Controllers/MachineController.cs
@@ -20,7 +20,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace MaintenanceChronicle.Api.Controllers;
 
 //Makes endpoints accessible only for users with Admin or GlobalAdmin roles
-[Authorize(Roles = $"{RoleTypes.Admin},{RoleTypes.GlobalAdmin}")]
+[Authorize(Roles = $"{RoleTypes.Admin},{RoleTypes.GlobalAdmin},{RoleTypes.Technician}")]
 [ApiController]
 public class MachineController(IMediator mediator) : ControllerBase
 {

--- a/src/MaintenanceChronicle.Api/Controllers/MaintenanceRecordController.cs
+++ b/src/MaintenanceChronicle.Api/Controllers/MaintenanceRecordController.cs
@@ -19,7 +19,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace MaintenanceChronicle.Api.Controllers;
 
 //Makes endpoints accessible only for users with Admin or GlobalAdmin roles
-[Authorize(Roles = $"{RoleTypes.Admin},{RoleTypes.GlobalAdmin}")]
+[Authorize(Roles = $"{RoleTypes.Admin},{RoleTypes.GlobalAdmin},{RoleTypes.Technician}")]
 [ApiController]
 public class MaintenanceRecordController(IMediator mediator) : ControllerBase
 {


### PR DESCRIPTION
This pull request includes changes to the authorization roles for several controllers in the `MaintenanceChronicle.Api` project. The most important changes are the addition of the `Technician` role to the authorization attributes of various controllers.

Authorization updates:

* [`src/MaintenanceChronicle.Api/Controllers/CustomerController.cs`](diffhunk://#diff-0cd7402d997b85c3b8c7b1eca1aa2f68c3a2c26441779cea172f3080dede7074L18-R18): Added `RoleTypes.Technician` to the authorized roles.
* [`src/MaintenanceChronicle.Api/Controllers/LocationController.cs`](diffhunk://#diff-949fbe721287cf2148448ddafabe2a9c1e4799e24acff02963286aa4ae9978b5L23-R23): Added `RoleTypes.Technician` to the authorized roles.
* [`src/MaintenanceChronicle.Api/Controllers/MachineController.cs`](diffhunk://#diff-c66d7e329f57637776df52165ed829e9693fb9b0d84f9901f0d3c3e1f5655744L23-R23): Added `RoleTypes.Technician` to the authorized roles.
* [`src/MaintenanceChronicle.Api/Controllers/MaintenanceRecordController.cs`](diffhunk://#diff-17b09ff048a39c4df3df93c86bf5c0ae6022be397624c2ad3a85c139960b6a4dL22-R22): Added `RoleTypes.Technician` to the authorized roles