### PR TITLE
Bug fix/fixes because fe

### DIFF
--- a/src/MaintenanceChronicle.Application.Contracts/MaintenanceRecords/Commands/Dto/ManageMaintenanceRecordDetailDto.cs
+++ b/src/MaintenanceChronicle.Application.Contracts/MaintenanceRecords/Commands/Dto/ManageMaintenanceRecordDetailDto.cs
@@ -25,6 +25,7 @@ public static class MaintenanceRecordDetailExtension
     /// <returns>Converted entity to <see cref="ManageMaintenanceRecordDetailDto"/></returns>
     public static ManageMaintenanceRecordDetailDto ToManageDto(this MaintenanceRecord entity) => new ManageMaintenanceRecordDetailDto()
     {
+        Id = entity.Id,
         MachineId = entity.MachineId,
         Description = entity.Description,
         Date = entity.Date.ToString(),

--- a/src/MaintenanceChronicle.Application.Contracts/MaintenanceRecords/Queries/Dto/MaintenanceRecordInListDto.cs
+++ b/src/MaintenanceChronicle.Application.Contracts/MaintenanceRecords/Queries/Dto/MaintenanceRecordInListDto.cs
@@ -32,7 +32,7 @@ public static class MaintenanceRecordInListExtension
         MachineName = entity.Machine.Model,
         MachineSerialNumber = entity.Machine.SerialNumber,
         Type = entity.Type.GetTypeName(),
-        Date = InstantPattern.CreateWithInvariantCulture("dd.MM.yyyy").Format(entity.Date),
+        Date = entity.Date.ToString(),
         Description = entity.Description,
         CustomerName = entity.Machine.Location.Customer.Name,
     };

--- a/src/MaintenanceChronicle.Application.Contracts/MaintenanceRecords/Queries/Dto/MaintenanceRecordInListForMachineDto.cs
+++ b/src/MaintenanceChronicle.Application.Contracts/MaintenanceRecords/Queries/Dto/MaintenanceRecordInListForMachineDto.cs
@@ -25,7 +25,7 @@ public static class MaintenanceRecordInListForMachineExtension
     {
         Id = entity.Id,
         Type = entity.Type.GetTypeName(),
-        Date = InstantPattern.CreateWithInvariantCulture("dd.MM.yyyy").Format(entity.Date),
+        Date = entity.Date.ToString(),
         Description = entity.Description,
     };
 }

--- a/src/MaintenanceChronicle.Application.Contracts/MaintenanceReminders/Queries/Dto/MaintenanceReminderDetailDto.cs
+++ b/src/MaintenanceChronicle.Application.Contracts/MaintenanceReminders/Queries/Dto/MaintenanceReminderDetailDto.cs
@@ -1,5 +1,6 @@
 using MaintenanceChronicle.Data.Entities.Business;
 using NodaTime;
+using NodaTime.Text;
 
 namespace MaintenanceChronicle.Application.Contracts.MaintenanceReminders.Queries.Dto;
 
@@ -7,7 +8,7 @@ public class MaintenanceReminderDetailDto
 {
     public Guid Id { get; set; }
     public string Description { get; set; } = String.Empty;
-    public Instant Date { get; set; }
+    public required string Date { get; set; }
     public Guid MachineId { get; set; }
 }
 /// <summary>
@@ -24,7 +25,7 @@ public static class MaintenanceReminderDetailDtoExtension
     {
         Id = mr.Id,
         Description = mr.Description,
-        Date = mr.Date,
+        Date = mr.Date.ToString(),
         MachineId = mr.MachineId,
     };
     /// <summary>
@@ -35,7 +36,7 @@ public static class MaintenanceReminderDetailDtoExtension
     public static void MapToEntity(this MaintenanceReminderDetailDto dto, MaintenanceReminder entity)
     {
         entity.Description = dto.Description;
-        entity.Date = dto.Date;
+        entity.Date = InstantPattern.General.Parse(dto.Date).Value;
         entity.MachineId = dto.MachineId;
     }
 }


### PR DESCRIPTION
This pull request includes several changes to the date handling in various DTOs and their extension methods within the `MaintenanceChronicle.Application.Contracts` namespace. The changes primarily focus on converting date objects to strings and vice versa to standardize date formatting across the application.

Changes to date handling:

* [`src/MaintenanceChronicle.Application.Contracts/MaintenanceRecords/Commands/Dto/ManageMaintenanceRecordDetailDto.cs`](diffhunk://#diff-5aabfbc58e2a5b30ba3667d0c5db29fd23ef2d8a08f8c9eff4b1df99c649453fR28): Added the `Id` property to the `ToManageDto` method.
* [`src/MaintenanceChronicle.Application.Contracts/MaintenanceRecords/Queries/Dto/MaintenanceRecordInListDto.cs`](diffhunk://#diff-3abe5113dbdd46f86025dbfcf56b32ebe0cffc629d104c0faba6b75e674deaf5L35-R35): Changed the `Date` property to use the `ToString()` method instead of a custom date format.
* [`src/MaintenanceChronicle.Application.Contracts/MaintenanceRecords/Queries/Dto/MaintenanceRecordInListForMachineDto.cs`](diffhunk://#diff-c5852a4fc2751c38e81c1723c88e5e6d44c026839426d0779cf3d37b181a3211L28-R28): Changed the `Date` property to use the `ToString()` method instead of a custom date format.

Changes to `MaintenanceReminderDetailDto`:

* [`src/MaintenanceChronicle.Application.Contracts/MaintenanceReminders/Queries/Dto/MaintenanceReminderDetailDto.cs`](diffhunk://#diff-63e17d3a943731c90dcd732be344fa01aa6dc7ebe020ef118735627c569c15acR3-R11): Changed the `Date` property from `Instant` to `string` and added `NodaTime.Text` namespace import.
* [`src/MaintenanceChronicle.Application.Contracts/MaintenanceReminders/Queries/Dto/MaintenanceReminderDetailDto.cs`](diffhunk://#diff-63e17d3a943731c90dcd732be344fa01aa6dc7ebe020ef118735627c569c15acL38-R39): Updated the `MapToEntity` method to parse the date string back to an `Instant` object.