### PR TITLE
Updated email paths for deckerization

### DIFF
--- a/src/MaintenanceChronicle.Utilities/EmailTemplates/EmailTemplateHelper.cs
+++ b/src/MaintenanceChronicle.Utilities/EmailTemplates/EmailTemplateHelper.cs
@@ -12,29 +12,6 @@ public class EmailTemplateHelper
     /// <returns>Email template</returns>
     public async Task<string> GetEmailConfirmationTemplate(string userName, string confirmationLink)
     {
-        string currentDirectory = Directory.GetCurrentDirectory();
-        Console.WriteLine("Current Directory: " + currentDirectory);
-
-        string[] files = Directory.GetFiles(currentDirectory);
-        string[] directories = Directory.GetDirectories(currentDirectory);
-
-        foreach (string file in files)
-        {
-            Console.WriteLine(file);
-        }
-
-        Console.WriteLine("---------------------------------------------------------------------------");
-        foreach (string dir in directories)
-        {
-            string[] filess = Directory.GetFiles(dir);
-            Console.WriteLine(dir);
-            foreach (string file in filess)
-            {
-                Console.WriteLine(file);
-            }
-        }
-        Console.WriteLine("---------------------------------------------------------------------------");
-
         var template = await File.ReadAllTextAsync("./EmailTemplates/EmailConfirmation.html");
         template = template.Replace("[UserName]", userName).Replace("[ConfirmationLink]", confirmationLink);
 
@@ -49,7 +26,7 @@ public class EmailTemplateHelper
     /// <returns>Email template</returns>
     public async Task<string> GetPasswordResetEmailTemplate(string userName, string passwordResetLink)
     {
-        var template = await File.ReadAllTextAsync("../MaintenanceChronicle.Utilities/EmailTemplates/PasswordReset.html");
+        var template = await File.ReadAllTextAsync("./EmailTemplates/PasswordReset.html");
         template = template.Replace("[UserName]", userName).Replace("[ResetLink]", passwordResetLink);
 
         return template;
@@ -63,7 +40,7 @@ public class EmailTemplateHelper
     /// <returns>Email template</returns>
     public async Task<string> GetUserInvitationEmailTemplate(string userName, string link)
     {
-        var template = await File.ReadAllTextAsync("../MaintenanceChronicle.Utilities/EmailTemplates/UserInvitationEmail.html");
+        var template = await File.ReadAllTextAsync("./EmailTemplates/UserInvitationEmail.html");
         template = template.Replace("[UserName]", userName).Replace("[Link]", link);
 
         return template;
@@ -81,7 +58,7 @@ public class EmailTemplateHelper
     public async Task<string> GetMaintenanceReminderEmailTemplate(string machineName, string machineSerialNumber,
         string date, string description, string locationName, string locationAddress)
     {
-        var template = await File.ReadAllTextAsync("../MaintenanceChronicle.Utilities/EmailTemplates/MaintenanceReminderEmail.html");
+        var template = await File.ReadAllTextAsync("./EmailTemplates/MaintenanceReminderEmail.html");
         template = template
             .Replace("[MachineName]", machineName)
             .Replace("[MachineSerialNumber]", machineSerialNumber)


### PR DESCRIPTION
This pull request includes several updates to the `EmailTemplateHelper` class in the `src/MaintenanceChronicle.Utilities/EmailTemplates/EmailTemplateHelper.cs` file. The changes primarily focus on improving the email template retrieval process by simplifying the directory paths and removing unnecessary code.

Simplification of directory paths:

* [`GetEmailConfirmationTemplate`](diffhunk://#diff-bdd84da7b71b88a13dc2770dbca94267331f4b08d45ae1ca09be36d55344dbfcL15-L37): Removed unnecessary code that printed the current directory and its contents, and simplified the path to the email template.
* [`GetPasswordResetEmailTemplate`](diffhunk://#diff-bdd84da7b71b88a13dc2770dbca94267331f4b08d45ae1ca09be36d55344dbfcL52-R29): Updated the path to the email template to a simpler relative path.
* [`GetUserInvitationEmailTemplate`](diffhunk://#diff-bdd84da7b71b88a13dc2770dbca94267331f4b08d45ae1ca09be36d55344dbfcL66-R43): Updated the path to the email template to a simpler relative path.
* [`GetMaintenanceReminderEmailTemplate`](diffhunk://#diff-bdd84da7b71b88a13dc2770dbca94267331f4b08d45ae1ca09be36d55344dbfcL84-R61): Updated the path to the email template to a simpler relative path.