### PR TITLE
Copied email templates to output directory.

### DIFF
--- a/src/MaintenanceChronicle.Utilities/MaintenanceChronicle.Utilities.csproj
+++ b/src/MaintenanceChronicle.Utilities/MaintenanceChronicle.Utilities.csproj
@@ -14,6 +14,15 @@
     <None Update="EmailTemplates\EmailConfirmation.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="EmailTemplates\MaintenanceReminderEmail.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="EmailTemplates\PasswordReset.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="EmailTemplates\UserInvitationEmail.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request includes updates to the `src/MaintenanceChronicle.Utilities/MaintenanceChronicle.Utilities.csproj` file to add new email templates to the project. The most important changes are the inclusion of several new email templates to be copied to the output directory.

New email templates added:

* [`EmailTemplates\MaintenanceReminderEmail.html`](diffhunk://#diff-b0a2efd9a537ea23989bbcf8f0769682d187b478ca7467a5afbab45f1d725c06R17-R25): Added to the project with `CopyToOutputDirectory` set to `PreserveNewest`.
* [`EmailTemplates\PasswordReset.html`](diffhunk://#diff-b0a2efd9a537ea23989bbcf8f0769682d187b478ca7467a5afbab45f1d725c06R17-R25): Added to the project with `CopyToOutputDirectory` set to `PreserveNewest`.
* [`EmailTemplates\UserInvitationEmail.html`](diffhunk://#diff-b0a2efd9a537ea23989bbcf8f0769682d187b478ca7467a5afbab45f1d725c06R17-R25): Added to the project with `CopyToOutputDirectory` set to `PreserveNewest`.