### PR TITLE
Added the installer pattern.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,10 @@ COPY ["src/MaintenanceChronicle.Application/MaintenanceChronicle.Application.csp
 COPY ["src/MaintenanceChronicle.BackgroundServices/MaintenanceChronicle.BackgroundServices.csproj", "MaintenanceChronicle.BackgroundServices/"]
 RUN dotnet restore "./MaintenanceChronicle.Api/MaintenanceChronicle.Api.csproj"
 COPY ./src ./
-COPY ./src/MaintenanceChronicle.Utilities/EmailTemplates/EmailConfirmation.html ./
-COPY ./src/MaintenanceChronicle.Utilities/EmailTemplates/PasswordReset.html ./
-COPY ./src/MaintenanceChronicle.Utilities/EmailTemplates/UserInvitationEmail.html ./
-COPY ./src/MaintenanceChronicle.Utilities/EmailTemplates/MaintenanceReminderEmail.html ./
+COPY ./src/MaintenanceChronicle.Utilities/EmailTemplates/EmailConfirmation.html ./MaintenanceChronicle.Utilities/EmailTemplates/
+COPY ./src/MaintenanceChronicle.Utilities/EmailTemplates/PasswordReset.html ./MaintenanceChronicle.Utilities/EmailTemplates/
+COPY ./src/MaintenanceChronicle.Utilities/EmailTemplates/UserInvitationEmail.html ./MaintenanceChronicle.Utilities/EmailTemplates/
+COPY ./src/MaintenanceChronicle.Utilities/EmailTemplates/MaintenanceReminderEmail.html ./MaintenanceChronicle.Utilities/EmailTemplates/
 WORKDIR "/src/MaintenanceChronicle.Api"
 RUN dotnet build "./MaintenanceChronicle.Api.csproj" -c $BUILD_CONFIGURATION -o /app/build
 

--- a/src/MaintenanceChronicle.Api/Installers/ApiInstaller.cs
+++ b/src/MaintenanceChronicle.Api/Installers/ApiInstaller.cs
@@ -1,0 +1,53 @@
+﻿using System.Reflection;
+using MaintenanceChronicle.Infrastructure;
+using Microsoft.OpenApi.Models;
+
+namespace MaintenanceChronicle.Api.Installers;
+
+public class ApiInstaller : IServiceInstaller
+{
+    public int Order => 6;
+
+    public void Install(IServiceCollection services, IConfiguration configuration)
+    {
+        //Use PATCH endpoints
+        services.AddControllers()
+            .AddNewtonsoftJson();
+
+        // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+        services.AddEndpointsApiExplorer();
+        services.AddSwaggerGen(options =>
+        {
+            options.SwaggerDoc("v1", new OpenApiInfo { Title = "MaintenanceChronicleApi", Version = "v1" });
+            var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+            var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
+            options.IncludeXmlComments(xmlPath);
+
+            // Configure JWT Authentication in Swagger
+            options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+            {
+                Name = "Authorization",
+                Type = SecuritySchemeType.Http,
+                Scheme = "bearer",
+                BearerFormat = "JWT",
+                In = ParameterLocation.Header,
+                Description = "Enter your JWT token without the 'Bearer' prefix.\n\nExample: abc123xyz"
+            });
+
+            options.AddSecurityRequirement(new OpenApiSecurityRequirement
+            {
+                {
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = "Bearer"
+                        }
+                    },
+                    Array.Empty<string>()
+                }
+            });
+        });
+    }
+}

--- a/src/MaintenanceChronicle.Api/Installers/IdentityInstaller.cs
+++ b/src/MaintenanceChronicle.Api/Installers/IdentityInstaller.cs
@@ -1,0 +1,64 @@
+﻿using MaintenanceChronicle.Data;
+using MaintenanceChronicle.Data.Entities.Account;
+using MaintenanceChronicle.Infrastructure;
+using MaintenanceChronicle.Utilities.Error;
+using MaintenanceChronicle.Utilities.Options;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
+
+namespace MaintenanceChronicle.Api.Installers;
+
+public class IdentityInstaller : IServiceInstaller
+{
+    public int Order => 3;
+    public void Install(IServiceCollection services, IConfiguration configuration)
+    {
+        //Identity
+        services.AddIdentity<User, Role>(options =>
+            {
+                options.User.RequireUniqueEmail = true;
+                options.SignIn.RequireConfirmedAccount = true;
+                options.Tokens.PasswordResetTokenProvider = TokenOptions.DefaultEmailProvider;
+            })
+            .AddEntityFrameworkStores<AppDbContext>()
+            .AddSignInManager()
+            .AddDefaultTokenProviders();
+
+        services.Configure<IdentityOptions>(options =>
+        {
+            options.Password.RequireDigit = true;
+            options.Password.RequireLowercase = true;
+            options.Password.RequireNonAlphanumeric = true;
+            options.Password.RequireUppercase = true;
+            options.Password.RequiredLength = 6;
+            options.Password.RequiredUniqueChars = 1;
+        });
+
+        //Configure authentication using JwtTokens
+        var jwtSettings = configuration.GetRequiredSection(nameof(JwtOptions)).Get<JwtOptions>();
+        if (jwtSettings == null)
+        {
+            throw new InternalServerException("Jwt settings was not found");
+        }
+
+        services.AddAuthentication(options =>
+        {
+            options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+            options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+        }).AddJwtBearer(options =>
+        {
+            options.TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidateLifetime = true,
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSettings.SecretKey)),
+                ValidIssuer = jwtSettings.Issuer,
+                ValidAudience = jwtSettings.Audience
+            };
+        });
+    }
+}

--- a/src/MaintenanceChronicle.Api/Installers/UtilitiesInstaller.cs
+++ b/src/MaintenanceChronicle.Api/Installers/UtilitiesInstaller.cs
@@ -1,0 +1,24 @@
+﻿using MaintenanceChronicle.Api.Utils;
+using MaintenanceChronicle.Infrastructure;
+using MaintenanceChronicle.Utilities.Helpers;
+using NodaTime;
+
+namespace MaintenanceChronicle.Api.Installers;
+
+public class UtilitiesInstaller : IServiceInstaller
+{
+    public int Order => 1;
+    public void Install(IServiceCollection services, IConfiguration configuration)
+    {
+        // Add services to the container.
+        //These services are needed for the ICurrentTenantProvider
+        services.AddHttpContextAccessor();
+        services.AddDataProtection();
+
+        //Method for global filter into db
+        services.AddScoped<ICurrentTenantProvider, CurrentTenantProvider>();
+
+        //Clock
+        services.AddSingleton<IClock>(SystemClock.Instance);
+    }
+}

--- a/src/MaintenanceChronicle.Api/Program.cs
+++ b/src/MaintenanceChronicle.Api/Program.cs
@@ -12,6 +12,7 @@ using MaintenanceChronicle.Application.Validators;
 using MaintenanceChronicle.BackgroundServices.BackgroundWorkers;
 using MaintenanceChronicle.Data.Entities.Account;
 using MaintenanceChronicle.Data.Entities.Business;
+using MaintenanceChronicle.Infrastructure;
 using MaintenanceChronicle.Utilities.Error;
 using MaintenanceChronicle.Utilities.Helpers;
 using Microsoft.OpenApi.Models;
@@ -29,133 +30,10 @@ if (!builder.Environment.IsDevelopment())
     builder.WebHost.UseUrls("http://*:80");
 }
 
-// Add services to the container.
-//These services are needed fot the ICurrentTenantProvider
-builder.Services.AddHttpContextAccessor();
-builder.Services.AddDataProtection();
-
-//Method for global filter into db
-builder.Services.AddScoped<ICurrentTenantProvider, CurrentTenantProvider>();
-
-//DbContext
-builder.Services.AddDbContext<AppDbContext>(options =>
-{
-    options.UseNpgsql(builder.Configuration.GetConnectionString("DbConnection"), optionsBuilder =>
-    {
-        optionsBuilder.UseNodaTime();
-        optionsBuilder.MapEnum<RecordType>("recordType");
-    });
-});
-
-//Use PATCH endpoints
-builder.Services.AddControllers()
-    .AddNewtonsoftJson();
-
-//Identity
-builder.Services.AddIdentity<User, Role>(options =>
-    {
-        options.User.RequireUniqueEmail = true;
-        options.SignIn.RequireConfirmedAccount = true;
-        options.Tokens.PasswordResetTokenProvider = TokenOptions.DefaultEmailProvider;
-    })
-    .AddEntityFrameworkStores<AppDbContext>()
-    .AddSignInManager()
-    .AddDefaultTokenProviders();
-
-builder.Services.Configure<IdentityOptions>(options =>
-{
-    options.Password.RequireDigit = true;
-    options.Password.RequireLowercase = true;
-    options.Password.RequireNonAlphanumeric = true;
-    options.Password.RequireUppercase = true;
-    options.Password.RequiredLength = 6;
-    options.Password.RequiredUniqueChars = 1;
-});
-
-//Configure JwtOptions
-builder.Services.Configure<JwtOptions>(builder.Configuration.GetSection(nameof(JwtOptions)));
-
-//Configure authentication using JwtTokens
-var jwtSettings = builder.Configuration.GetRequiredSection(nameof(JwtOptions)).Get<JwtOptions>();
-if (jwtSettings == null)
-{
-    throw new InternalServerException("Jwt settings was not found");
-}
-
-builder.Services.AddAuthentication(options =>
-{
-    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-}).AddJwtBearer(options =>
-    {
-        options.TokenValidationParameters = new TokenValidationParameters
-        {
-            ValidateIssuer = true,
-            ValidateAudience = true,
-            ValidateLifetime = true,
-            ValidateIssuerSigningKey = true,
-            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSettings.SecretKey)),
-            ValidIssuer = jwtSettings.Issuer,
-            ValidAudience = jwtSettings.Audience
-        };
-    });
-
-//MediatR
-builder.Services.AddMediatR(cfg =>
-{
-    cfg.RegisterServicesFromAssembly(typeof(RequestHandlerRegistrationHelper).Assembly);
-});
-
-//Smtp Options
-builder.Services.Configure<SmtpOptions>(builder.Configuration.GetSection("SmtpOptions"));
-
-//Environment options
-builder.Services.Configure<EnvironmentOptions>(builder.Configuration.GetSection("EnvironmentOptions"));
-
-//Clock
-builder.Services.AddSingleton<IClock>(SystemClock.Instance);
-
-//Adding EmailSenderBackgroundService into HostedServices
-builder.Services.AddHostedService<EmailSenderBackgroundService>();
-
-//Adding MaintenanceReminderBackgroundService into HostedServices
-builder.Services.AddHostedService<MaintenanceReminderBackgroundService>();
-
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen(options =>
-{
-    options.SwaggerDoc("v1", new OpenApiInfo { Title = "MaintenanceChronicleApi", Version = "v1" });
-    var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
-    var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
-    options.IncludeXmlComments(xmlPath);
-
-    // Configure JWT Authentication in Swagger
-    options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
-    {
-        Name = "Authorization",
-        Type = SecuritySchemeType.Http,
-        Scheme = "bearer",
-        BearerFormat = "JWT",
-        In = ParameterLocation.Header,
-        Description = "Enter your JWT token without the 'Bearer' prefix.\n\nExample: abc123xyz"
-    });
-
-    options.AddSecurityRequirement(new OpenApiSecurityRequirement
-    {
-        {
-            new OpenApiSecurityScheme
-            {
-                Reference = new OpenApiReference
-                {
-                    Type = ReferenceType.SecurityScheme,
-                    Id = "Bearer"
-                }
-            },
-            Array.Empty<string>()
-        }
-    });
-});
+builder.Services.InstallServices(
+    builder.Configuration,
+    Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!
+);
 
 var app = builder.Build();
 

--- a/src/MaintenanceChronicle.Application/MaintenanceChronicle.Application.csproj
+++ b/src/MaintenanceChronicle.Application/MaintenanceChronicle.Application.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <ProjectReference Include="..\MaintenanceChronicle.Application.Contracts\MaintenanceChronicle.Application.Contracts.csproj" />
       <ProjectReference Include="..\MaintenanceChronicle.Data\MaintenanceChronicle.Data.csproj" />
+      <ProjectReference Include="..\MaintenanceChronicle.Infrastructure\MaintenanceChronicle.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/MaintenanceChronicle.Application/MediatrInstaller.cs
+++ b/src/MaintenanceChronicle.Application/MediatrInstaller.cs
@@ -1,0 +1,21 @@
+using MaintenanceChronicle.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MaintenanceChronicle.Application;
+
+public class MediatrInstaller : IServiceInstaller
+{
+    public int Order => 4;
+    /// <summary>
+    /// Installs the services for MediatR
+    /// </summary>
+    /// <param name="services">Service collection to add services to</param>
+    public void Install(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddMediatR(cfg =>
+        {
+            cfg.RegisterServicesFromAssembly(typeof(MediatrInstaller).Assembly);
+        });
+    }
+}

--- a/src/MaintenanceChronicle.Application/RequestHandlerRegistrationHelper.cs
+++ b/src/MaintenanceChronicle.Application/RequestHandlerRegistrationHelper.cs
@@ -1,7 +1,0 @@
-namespace MaintenanceChronicle.Application;
-/// <summary>
-/// Dummy class to help with registration of request handlers
-/// </summary>
-public class RequestHandlerRegistrationHelper
-{
-}

--- a/src/MaintenanceChronicle.BackgroundServices/BackgroundServicesInstaller.cs
+++ b/src/MaintenanceChronicle.BackgroundServices/BackgroundServicesInstaller.cs
@@ -1,0 +1,19 @@
+﻿using MaintenanceChronicle.BackgroundServices.BackgroundWorkers;
+using MaintenanceChronicle.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MaintenanceChronicle.BackgroundServices;
+
+public class BackgroundServicesInstaller : IServiceInstaller
+{
+    public int Order => 5;
+    public void Install(IServiceCollection services, IConfiguration configuration)
+    {
+        //Adding EmailSenderBackgroundService into HostedServices
+        services.AddHostedService<EmailSenderBackgroundService>();
+
+        //Adding MaintenanceReminderBackgroundService into HostedServices
+        services.AddHostedService<MaintenanceReminderBackgroundService>();
+    }
+}

--- a/src/MaintenanceChronicle.Data/DatabaseInstaller.cs
+++ b/src/MaintenanceChronicle.Data/DatabaseInstaller.cs
@@ -1,0 +1,24 @@
+﻿using MaintenanceChronicle.Data.Entities.Business;
+using MaintenanceChronicle.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MaintenanceChronicle.Data;
+
+public class DatabaseInstaller : IServiceInstaller
+{
+    public int Order => 2;
+    public void Install(IServiceCollection services, IConfiguration configuration)
+    {
+        //DbContext
+        services.AddDbContext<AppDbContext>(options =>
+        {
+            options.UseNpgsql(configuration.GetConnectionString("DbConnection"), optionsBuilder =>
+            {
+                optionsBuilder.UseNodaTime();
+                optionsBuilder.MapEnum<RecordType>("recordType");
+            });
+        });
+    }
+}

--- a/src/MaintenanceChronicle.Infrastructure/IServiceInstaller.cs
+++ b/src/MaintenanceChronicle.Infrastructure/IServiceInstaller.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MaintenanceChronicle.Infrastructure;
+
+public interface IServiceInstaller
+{
+    int Order { get; }
+    void Install(IServiceCollection services, IConfiguration configuration);
+}

--- a/src/MaintenanceChronicle.Infrastructure/MaintenanceChronicle.Infrastructure.csproj
+++ b/src/MaintenanceChronicle.Infrastructure/MaintenanceChronicle.Infrastructure.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.8" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8" />
+	</ItemGroup>
+
+</Project>

--- a/src/MaintenanceChronicle.Infrastructure/ServiceInstallerExtensions.cs
+++ b/src/MaintenanceChronicle.Infrastructure/ServiceInstallerExtensions.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+
+namespace MaintenanceChronicle.Infrastructure;
+
+public static class ServiceInstallerExtensions
+{
+    public static IServiceCollection InstallServices(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string basePath)
+    {
+        //The SearchOption.TopDirectoryOnly may be a problem with Submodules or a different directory structure.
+        var assemblyFiles = Directory.GetFiles(basePath, "*.dll", SearchOption.TopDirectoryOnly);
+
+        var assemblies = new List<Assembly>();
+
+        foreach (var file in assemblyFiles)
+        {
+            // Avoid loading system/framework assemblies, and only load assemblies that match the current assembly's name prefix.
+            if (!Path.GetFileName(file).StartsWith(Assembly.GetExecutingAssembly().ManifestModule.Name.Split(".")[0]))
+                continue;
+
+            var assembly = Assembly.LoadFrom(file);
+            assemblies.Add(assembly);
+        }
+
+        var installers = assemblies
+            .SelectMany(a => a.DefinedTypes)
+            .Where(IsAssignableToType<IServiceInstaller>)
+            .Where(t => !t.IsInterface && !t.IsAbstract)
+            .Select(Activator.CreateInstance)
+            .Cast<IServiceInstaller>()
+            .ToArray();
+
+        //Important: installers must be used in a specific order.
+        installers = installers
+            .OrderBy(i => i.Order).ToArray();
+
+        foreach (var installer in installers)
+        {
+            installer.Install(services, configuration);
+        }
+
+        return services;
+    }
+
+    private static bool IsAssignableToType<T>(TypeInfo typeInfo) =>
+        typeof(T).IsAssignableFrom(typeInfo) &&
+        !typeInfo.IsInterface &&
+        !typeInfo.IsAbstract;
+}

--- a/src/MaintenanceChronicle.Utilities/ConfigurationInstaller.cs
+++ b/src/MaintenanceChronicle.Utilities/ConfigurationInstaller.cs
@@ -1,0 +1,21 @@
+﻿using MaintenanceChronicle.Infrastructure;
+using MaintenanceChronicle.Utilities.Options;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MaintenanceChronicle.Utilities;
+
+public class ConfigurationInstaller : IServiceInstaller
+{
+    public int Order => 0;
+    public void Install(IServiceCollection services, IConfiguration configuration)
+    {
+        //Configure JwtOptions
+        services.Configure<JwtOptions>(configuration.GetSection(nameof(JwtOptions)));
+
+        services.Configure<SmtpOptions>(configuration.GetSection(nameof(SmtpOptions)));
+
+        //Environment options
+        services.Configure<EnvironmentOptions>(configuration.GetSection(nameof(EnvironmentOptions)));
+    }
+}

--- a/src/MaintenanceChronicle.Utilities/MaintenanceChronicle.Utilities.csproj
+++ b/src/MaintenanceChronicle.Utilities/MaintenanceChronicle.Utilities.csproj
@@ -11,6 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\MaintenanceChronicle.Infrastructure\MaintenanceChronicle.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="EmailTemplates\EmailConfirmation.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/MaintenanceChronicle.sln
+++ b/src/MaintenanceChronicle.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MaintenanceChronicle.Utilit
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MaintenanceChronicle.BackgroundServices", "MaintenanceChronicle.BackgroundServices\MaintenanceChronicle.BackgroundServices.csproj", "{DC795C30-4134-4B7D-A6F6-D6E1CEB40934}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MaintenanceChronicle.Infrastructure", "MaintenanceChronicle.Infrastructure\MaintenanceChronicle.Infrastructure.csproj", "{43776E4C-E205-4ADF-9F2F-157BE834918F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{DC795C30-4134-4B7D-A6F6-D6E1CEB40934}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DC795C30-4134-4B7D-A6F6-D6E1CEB40934}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DC795C30-4134-4B7D-A6F6-D6E1CEB40934}.Release|Any CPU.Build.0 = Release|Any CPU
+		{43776E4C-E205-4ADF-9F2F-157BE834918F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{43776E4C-E205-4ADF-9F2F-157BE834918F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{43776E4C-E205-4ADF-9F2F-157BE834918F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{43776E4C-E205-4ADF-9F2F-157BE834918F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This pull request introduces a modular and extensible approach to service registration using the new `IServiceInstaller` interface and a reflection-based discovery mechanism. Service registrations previously located in `Program.cs` are now encapsulated in installer classes across the solution, improving maintainability and separation of concerns. Additionally, a new `MaintenanceChronicle.Infrastructure` project is added to house shared infrastructure code. Minor Dockerfile and project reference adjustments are also included.

**❗Major issues❗**
- When installing services, I found a big problem. As we know the services must be installed in a specific order. That is because when i try to add identity to services before i add the Database context the action will fail. That's why it is important to add the order property to `IServiceInstaller`.

Key changes:

**Service Registration Refactor and Infrastructure Setup**
- Introduced the `IServiceInstaller` interface and implemented the `ServiceInstallerExtensions.InstallServices` method for automatic, ordered discovery and execution of service installers via reflection. This enables modular service registration and reduces clutter in `Program.cs`. (`src/MaintenanceChronicle.Infrastructure/IServiceInstaller.cs`, `src/MaintenanceChronicle.Infrastructure/ServiceInstallerExtensions.cs`, `src/MaintenanceChronicle.Infrastructure/MaintenanceChronicle.Infrastructure.csproj`, `src/MaintenanceChronicle.sln`, `src/MaintenanceChronicle.Application/MaintenanceChronicle.Application.csproj`, `src/MaintenanceChronicle.Utilities/MaintenanceChronicle.Utilities.csproj`) [[1]](diffhunk://#diff-f272478203753e2b5f221aa5265777e5b2b9c6a0b476ed01d0ef562976811f0eR1-R10) [[2]](diffhunk://#diff-4c83cf083f212563ccbc3d7601b4e443a6e3340e06027003835fe6d98e438f9fR1-R53) [[3]](diffhunk://#diff-accd4bc65908e36b0aa17dda88b47b55351a0f9b03e3ccf5baa3493e086d4d09R1-R14) [[4]](diffhunk://#diff-9d21bd94b4cacb8e513ea080ce11e529a0f924a858dd409168b99fb5589d93c9R18-R19) [[5]](diffhunk://#diff-9d21bd94b4cacb8e513ea080ce11e529a0f924a858dd409168b99fb5589d93c9R50-R53) [[6]](diffhunk://#diff-3ba6a402c4e83b62d4d118e70ad36a641a15ac6a6d5c14d659ee150acc49ff02R26) [[7]](diffhunk://#diff-b0a2efd9a537ea23989bbcf8f0769682d187b478ca7467a5afbab45f1d725c06R13-R16)

**Migration of Service Registrations to Installers**
- Moved configuration, database, identity, MediatR, background services, utilities, and API/Swagger registrations into dedicated installer classes (`ConfigurationInstaller`, `DatabaseInstaller`, `IdentityInstaller`, `MediatrInstaller`, `BackgroundServicesInstaller`, `UtilitiesInstaller`, `ApiInstaller`). (`src/MaintenanceChronicle.Utilities/ConfigurationInstaller.cs`, `src/MaintenanceChronicle.Data/DatabaseInstaller.cs`, `src/MaintenanceChronicle.Api/Installers/IdentityInstaller.cs`, `src/MaintenanceChronicle.Application/MediatrInstaller.cs`, `src/MaintenanceChronicle.BackgroundServices/BackgroundServicesInstaller.cs`, `src/MaintenanceChronicle.Api/Installers/UtilitiesInstaller.cs`, `src/MaintenanceChronicle.Api/Installers/ApiInstaller.cs`) [[1]](diffhunk://#diff-6d414a4388d3ac684bb3a00d4f4a1ea3f4fc5eab22f09ce6d31e86b82fadb654R1-R21) [[2]](diffhunk://#diff-cd06ae4aad67c396e19f3ecc3a761985bbf3b37354bf65dcd832159652a97d67R1-R24) [[3]](diffhunk://#diff-54849a3fbec60ed458332626808b097afa27a39dd283c0de7120a9a339e0b820R1-R64) [[4]](diffhunk://#diff-e09a6514560823ef862e9e76de8add2b48d44710526a3baa00665a410de28a2eR1-R21) [[5]](diffhunk://#diff-020b078b7d430b8e8fb5ffa2842f5a1b7919e64ff3b7099219b20f004c6aa9c9R1-R19) [[6]](diffhunk://#diff-98746f954690b87c35ff6d7982c448e703d133f3fdf531846f52c84e8bff2169R1-R24) [[7]](diffhunk://#diff-60076bf7190d36192ec72fdc68ff21e0923d4d76f8386143b981d22db7be754dR1-R53)

**Simplification of `Program.cs`**
- Replaced all explicit service registrations with a single call to `InstallServices`, delegating setup to the discovered installers and significantly reducing boilerplate. (`src/MaintenanceChronicle.Api/Program.cs`)

**Cleanup and Minor Adjustments**
- Removed the obsolete `RequestHandlerRegistrationHelper` class, which is no longer needed after the MediatR installer refactor. (`src/MaintenanceChronicle.Application/RequestHandlerRegistrationHelper.cs`)
- Adjusted Dockerfile `COPY` commands to place email templates in the correct subdirectory, ensuring proper build output. (`Dockerfile`)

These changes provide a cleaner and more scalable way to manage dependency injection and service configuration across the solution.